### PR TITLE
kodi - no longer use pipplware repo / depends changes

### DIFF
--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -21,22 +21,17 @@ function _update_hook_kodi() {
 }
 
 function depends_kodi() {
-    if isPlatform "rpi"; then
-        if [[ "$md_mode" == "install" ]]; then
-            # remove old repository
-            rm -f /etc/apt/sources.list.d/mene.list
-            echo "deb http://dl.bintray.com/pipplware/dists/jessie/main/binary/ ./" >/etc/apt/sources.list.d/pipplware.list
-            # additional repository with armv7/8 binaries
-            if ! isPlatform "armv6"; then
-                echo "deb http://dl.bintray.com/pipplware/dists/jessie/armv7/binary/ ./" >>/etc/apt/sources.list.d/pipplware.list
-            fi
-            wget -q -O- http://pipplware.pplware.pt/pipplware/key.asc | apt-key add - >/dev/null
-        else
-            rm -f /etc/apt/sources.list.d/pipplware.list
-            apt-key del 4096R/BAA567BB >/dev/null
+    if [[ "$md_mode" == "install" ]]; then
+        if isPlatform "x86"; then
+            apt-add-repository -y ppa:team-xbmc/ppa
         fi
-    elif isPlatform "x86"; then
-        apt-add-repository -y ppa:team-xbmc/ppa
+    fi
+
+    if isPlatform "rpi"; then
+        # remove old repositories
+        rm -f /etc/apt/sources.list.d/mene.list
+        rm -f /etc/apt/sources.list.d/pipplware.list
+        apt-key del 4096R/BAA567BB >/dev/null
     fi
 
     getDepends policykit-1


### PR DESCRIPTION
 * kodi packages are now uploaded to the main raspbian repo
 * only add repository on x86 in install mode
 * only try to remove old mene / pipplware repos if on rpi