### PR TITLE
Revert "joy2key: use USR1 signal handler with more graceful exit hand…

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1029,8 +1029,8 @@ function joy2keyStart() {
 ## @brief Stop previously started joy2key.py process.
 function joy2keyStop() {
     if [[ -n $__joy2key_pid ]]; then
-        kill -USR1 $__joy2key_pid
-        wait $__joy2key_pid 2>/dev/null
+        kill -INT $__joy2key_pid 2>/dev/null
+        sleep 1
     fi
 }
 

--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -212,8 +212,6 @@ def process_event(event):
     return False
 
 signal.signal(signal.SIGINT, signal_handler)
-signal.signal(signal.SIGTERM, signal_handler)
-signal.signal(signal.SIGUSR1, signal_handler)
 
 js_button_codes = {}
 button_codes = []

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -123,8 +123,7 @@ function start_joy2key() {
 
 function stop_joy2key() {
     if [[ -n "$JOY2KEY_PID" ]]; then
-        kill -USR1 "$JOY2KEY_PID"
-        wait "$JOY2KEY_PID" 2>/dev/null
+        kill -INT "$JOY2KEY_PID"
     fi
 }
 


### PR DESCRIPTION
…ling"

This reverts commit d4c653a3d28108e4199b2f49b2bba10b2d6b338b.

on the RPI1 the wait in runcommand can sit there forever. Adding a sleep helps, but
this isn't ideal. Problem is likely due to the signal hander not yet being set up on the rpi1
when launching joy2key when the kill is executed.