### PR TITLE
wikidocs - added mdx_truly_sane_lists markdown extension to be used i…

### DIFF
--- a/scriptmodules/admin/wikidocs.sh
+++ b/scriptmodules/admin/wikidocs.sh
@@ -15,7 +15,7 @@ rp_module_section=""
 
 function depends_wikidocs() {
     getDepends python3 python3-pip libyaml-dev
-    pip3 install --upgrade mkdocs mkdocs-material
+    pip3 install --upgrade mkdocs mkdocs-material mdx_truly_sane_lists
 }
 
 function sources_wikidocs() {


### PR DESCRIPTION
…n mkdocs so the lists indent closer matches to github